### PR TITLE
Remove calcite and unused imports

### DIFF
--- a/classicViewer.html
+++ b/classicViewer.html
@@ -3,6 +3,11 @@
   <head lang="en">
     <meta charset="UTF-8" />
     <title>Stream Service Viewer</title>
+    <!-- Gives us calcite based design - does not seem to interfere with the 3x css -->
+    <link
+      rel="stylesheet"
+      href="https://js.arcgis.com/4.25/esri/themes/light/main.css"
+    />
     <link
       rel="stylesheet"
       href="https://js.arcgis.com/3.42/esri/css/esri.css"
@@ -296,7 +301,7 @@
           </div>
         </div>
         <div class="config-content">
-          <div class="input-group input-group-full">
+          <div class="input-group input-group-full input-group-flex">
             <input
               type="text"
               id="streamServiceUrl"
@@ -326,7 +331,7 @@
               Clear Previous Observations
             </button>
           </div>
-          <div class="input-group input-group-full">
+          <div class="input-group input-group-full input-group-flex">
             <input
               id="expressionFilter"
               class="esri-input"

--- a/classicViewer.html
+++ b/classicViewer.html
@@ -34,7 +34,7 @@
         "dijit/TitlePane",
         "dijit/layout/ContentPane",
         "dojo/domReady!"
-      ], function(
+      ], function (
         parser,
         Map,
         Draw,
@@ -77,7 +77,7 @@
           on(
             dojo.byId("controls"),
             on.selector(".config-header", "click"),
-            function(e) {
+            function (e) {
               if (e.target.type !== "checkbox") {
                 const sectionWrapper = e.selectorTarget.parentNode;
 
@@ -92,20 +92,20 @@
           );
           on(dojo.byId("subscribeUnsubscribe"), "click", toggleSubscription);
           on(dojo.byId("toggleStreamLayer"), "click", toggleStreamLayer);
-          on(dojo.byId("clearPreviousObservations"), "click", function() {
+          on(dojo.byId("clearPreviousObservations"), "click", function () {
             if (streamLayer) streamLayer.clear();
           });
           on(dojo.byId("applyWhereClause"), "click", applyWhereClause);
           on(dojo.byId("applySpatialFilter"), "click", applySpatialFilter);
           on(dojo.byId("clearSpatialFilter"), "click", clearSpatialFilter);
-          on(drawTools, "draw-end", function(evt) {
+          on(drawTools, "draw-end", function (evt) {
             drawTools.deactivate();
             spatialFilter = evt.geometry;
             drawSpatialFilter(spatialFilter);
             if (streamLayer) streamLayer.setGeometryDefinition(spatialFilter);
             domAttr.remove(dojo.byId("clearSpatialFilter"), "disabled");
           });
-          on(dojo.byId("switchViewer"), "click", function() {
+          on(dojo.byId("switchViewer"), "click", function () {
             window.location.href = "./currentViewer.html";
           });
         }
@@ -156,18 +156,18 @@
           });
 
           //When layer loads, register listeners for layer events and add layer to map
-          streamLayer.on("load", function() {
+          streamLayer.on("load", function () {
             //Connect and Disconnect events
             streamLayer.on("connect", onLayerConnected);
             streamLayer.on("disconnect", onLayerDisconnected);
             streamLayer.on("message", onMessage);
-            streamLayer.on("connection-error", function() {
+            streamLayer.on("connection-error", function () {
               removeStreamLayer();
               alert("Error connecting to the Stream Service");
             });
 
             // Add popup template
-            const fieldInfos = array.map(streamLayer.fields, function(field) {
+            const fieldInfos = array.map(streamLayer.fields, function (field) {
               return {
                 fieldName: field.name,
                 label: field.alias,
@@ -200,16 +200,28 @@
         function onLayerAdded(event) {
           if (streamLayer && streamLayer.name === event.layer.name) {
             dojo.byId("toggleStreamLayer").innerText = "Remove Stream Layer";
-            domClass.add(dojo.byId("clearPreviousObservations"), "esri-button--disabled");
-            domClass.remove(dojo.byId("subscribeUnsubscribe"), "esri-button--disabled");
+            domClass.add(
+              dojo.byId("clearPreviousObservations"),
+              "esri-button--disabled"
+            );
+            domClass.remove(
+              dojo.byId("subscribeUnsubscribe"),
+              "esri-button--disabled"
+            );
           }
         }
 
         function onLayerRemoved() {
           dojo.byId("toggleStreamLayer").innerText = "Add Stream Layer";
-          domClass.add(dojo.byId("clearPreviousObservations"), "esri-button--disabled");
+          domClass.add(
+            dojo.byId("clearPreviousObservations"),
+            "esri-button--disabled"
+          );
           dojo.byId("subscribeUnsubscribe").innerText = "Unsubscribe";
-          domClass.add(dojo.byId("subscribeUnsubscribe"), "esri-button--disabled");
+          domClass.add(
+            dojo.byId("subscribeUnsubscribe"),
+            "esri-button--disabled"
+          );
         }
 
         function onLayerConnected() {
@@ -221,7 +233,29 @@
         }
 
         function onMessage(msg) {
-          if (msg.error) alert(msg.error[0]);
+          if (msg.error) {
+            alert(msg.error[0]);
+          } else if (msg.filter) {
+            if (
+              msg.filter.hasOwnProperty("where") ||
+              msg.filter.hasOwnProperty("geometry")
+            ) {
+              alert(
+                "Successfully updated the filter. \nAttribute Filter: " +
+                  (msg.filter.where || "") +
+                  "\nSpatial Filter: " +
+                  (msg.filter.geometry
+                    ? typeof msg.filter.geometry === "object"
+                      ? JSON.stringify(msg.filter.geometry)
+                      : msg.filter.geometry
+                    : "")
+              );
+            } else {
+              alert(
+                "Successfully updated the filter. \n\nAttribute Filter: \n Spatial Filter: "
+              );
+            }
+          }
         }
 
         /************************************************
@@ -243,7 +277,10 @@
           spatialFilter = null;
           map.graphics.clear();
           if (streamLayer) streamLayer.setGeometryDefinition(null);
-          domClass.add(dojo.byId("clearSpatialFilter"), "esri-button--disabled");
+          domClass.add(
+            dojo.byId("clearSpatialFilter"),
+            "esri-button--disabled"
+          );
         }
 
         function drawSpatialFilter(bbox) {
@@ -280,7 +317,7 @@
         >
           <div
             data-dojo-type="dijit/layout/ContentPane"
-            style="width:380px; height:280px; overflow:auto;"
+            style="width: 380px; height: 280px; overflow: auto"
           >
             <div id="basemapGallery"></div>
           </div>

--- a/classicViewer.html
+++ b/classicViewer.html
@@ -7,18 +7,8 @@
       rel="stylesheet"
       href="https://js.arcgis.com/3.42/esri/css/esri.css"
     />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://js.arcgis.com/calcite-components/1.0.0-beta.97/calcite.css"
-    />
     <link rel="stylesheet" href="./streamServiceViewerStyles.css" />
     <script src="https://js.arcgis.com/3.42/"></script>
-    <script src="https://use.fontawesome.com/9482a0b1d1.js"></script>
-    <script
-      type="module"
-      src="https://js.arcgis.com/calcite-components/1.0.0-beta.97/calcite.esm.js"
-    ></script>
     <script>
       require([
         "dojo/parser",
@@ -56,7 +46,7 @@
         domClass,
         domAttr
       ) {
-        var map, drawTools, streamLayer, spatialFilter, expressionFilter;
+        let map, drawTools, streamLayer, spatialFilter, expressionFilter;
 
         parser.parse();
 
@@ -84,7 +74,7 @@
             on.selector(".config-header", "click"),
             function(e) {
               if (e.target.type !== "checkbox") {
-                var sectionWrapper = e.selectorTarget.parentNode;
+                const sectionWrapper = e.selectorTarget.parentNode;
 
                 domClass.toggle(sectionWrapper, "section-hidden");
               }
@@ -127,25 +117,6 @@
           );
         }
 
-        function createToaster(title, message, color) {
-          var calciteAlert = document.createElement("calcite-alert");
-          var alertTitle = document.createElement("div");
-          var alertMessage = document.createElement("div");
-
-          calciteAlert.setAttribute("open", "true");
-          calciteAlert.setAttribute("color", color);
-          calciteAlert.setAttribute("placement", "bottom-end");
-          alertTitle.setAttribute("slot", "title");
-          alertMessage.setAttribute("slot", "message");
-
-          alertTitle.innerText = title;
-          alertMessage.innerText = message;
-
-          calciteAlert.appendChild(alertTitle);
-          calciteAlert.appendChild(alertMessage);
-          document.getElementsByTagName("body")[0].appendChild(calciteAlert);
-        }
-
         /*************************************************
          *
          * Functions to add and remove Stream Layer
@@ -169,7 +140,7 @@
 
         function addStreamLayer() {
           //url to stream service
-          var svcUrl = dojo.byId("streamServiceUrl").value;
+          const svcUrl = dojo.byId("streamServiceUrl").value;
 
           //construct Stream Layer
           streamLayer = new StreamLayer(svcUrl, {
@@ -186,16 +157,12 @@
             streamLayer.on("disconnect", onLayerDisconnected);
             streamLayer.on("message", onMessage);
             streamLayer.on("connection-error", function() {
-              createToaster(
-                "Alert",
-                "Error connecting to the Stream Service",
-                "red"
-              );
               removeStreamLayer();
+              alert("Error connecting to the Stream Service");
             });
 
             // Add popup template
-            var fieldInfos = array.map(streamLayer.fields, function(field) {
+            const fieldInfos = array.map(streamLayer.fields, function(field) {
               return {
                 fieldName: field.name,
                 label: field.alias,
@@ -203,7 +170,7 @@
               };
             });
 
-            var template = new PopupTemplate({
+            const template = new PopupTemplate({
               fieldInfos: fieldInfos
             });
             streamLayer.setInfoTemplate(template);
@@ -228,20 +195,16 @@
         function onLayerAdded(event) {
           if (streamLayer && streamLayer.name === event.layer.name) {
             dojo.byId("toggleStreamLayer").innerText = "Remove Stream Layer";
-            domAttr.remove(dojo.byId("clearPreviousObservations"), "disabled");
-            domAttr.remove(dojo.byId("subscribeUnsubscribe"), "disabled");
+            domClass.add(dojo.byId("clearPreviousObservations"), "esri-button--disabled");
+            domClass.remove(dojo.byId("subscribeUnsubscribe"), "esri-button--disabled");
           }
         }
 
         function onLayerRemoved() {
           dojo.byId("toggleStreamLayer").innerText = "Add Stream Layer";
-          domAttr.set(
-            dojo.byId("clearPreviousObservations"),
-            "disabled",
-            "true"
-          );
+          domClass.add(dojo.byId("clearPreviousObservations"), "esri-button--disabled");
           dojo.byId("subscribeUnsubscribe").innerText = "Unsubscribe";
-          domAttr.set(dojo.byId("subscribeUnsubscribe"), "disabled", "true");
+          domClass.add(dojo.byId("subscribeUnsubscribe"), "esri-button--disabled");
         }
 
         function onLayerConnected() {
@@ -253,33 +216,7 @@
         }
 
         function onMessage(msg) {
-          if (msg.error) {
-            createToaster("Alert", msg.error[0], "red");
-          } else if (msg.filter) {
-            if (
-              msg.filter.hasOwnProperty("where") ||
-              msg.filter.hasOwnProperty("geometry")
-            ) {
-              createToaster(
-                "Success",
-                "Successfully updated the filter. \nAttribute Filter: " +
-                  (msg.filter.where || "") +
-                  "\nSpatial Filter: " +
-                  (msg.filter.geometry
-                    ? typeof msg.filter.geometry === "object"
-                      ? JSON.stringify(msg.filter.geometry)
-                      : msg.filter.geometry
-                    : ""),
-                "green"
-              );
-            } else {
-              createToaster(
-                "Success",
-                "Successfully updated the filter. \n\nAttribute Filter: \n Spatial Filter: ",
-                "green"
-              );
-            }
-          }
+          if (msg.error) alert(msg.error[0]);
         }
 
         /************************************************
@@ -301,7 +238,7 @@
           spatialFilter = null;
           map.graphics.clear();
           if (streamLayer) streamLayer.setGeometryDefinition(null);
-          domAttr.set(dojo.byId("clearSpatialFilter"), "disabled", "true");
+          domClass.add(dojo.byId("clearSpatialFilter"), "esri-button--disabled");
         }
 
         function drawSpatialFilter(bbox) {
@@ -329,7 +266,6 @@
       });
     </script>
   </head>
-
   <body class="flat">
     <div id="map">
       <div class="basemapGallery-container">
@@ -355,67 +291,72 @@
         <div class="config-header">
           <h2>Layers</h2>
           <div class="header-actions-group">
-            <i class="fa"></i>
+            <i id="collapsedPane" class="fa flat-chevron-down"></i>
+            <i id="expandedPane" class="fa flat-chevron-up"></i>
           </div>
         </div>
         <div class="config-content">
           <div class="input-group input-group-full">
-            <calcite-input
+            <input
               type="text"
               id="streamServiceUrl"
+              class="esri-input"
               placeholder="Stream layer url"
-              value="https://geoeventsample1.esri.com/server/rest/services/FAAStream/StreamServer"
-            ></calcite-input>
+              value="https:/geoeventsample1.esri.com/server/rest/services/FAAStream/StreamServer"
+            />
           </div>
           <div class="input-group input-group-full">
-            <calcite-button id="toggleStreamLayer" width="full"
-              >Add Stream Layer</calcite-button
-            >
+            <button id="toggleStreamLayer" class="esri-button">
+              Add Stream Layer
+            </button>
           </div>
           <div class="input-group input-group-full">
-            <calcite-button
+            <button
               id="subscribeUnsubscribe"
-              width="full"
-              disabled="true"
-              >Unsubscribe</calcite-button
+              class="esri-button esri-button--disabled"
             >
+              Unsubscribe
+            </button>
           </div>
           <div class="input-group input-group-full">
-            <calcite-button
+            <button
               id="clearPreviousObservations"
-              width="full"
-              disabled="true"
-              >Clear Previous Observations</calcite-button
+              class="esri-button esri-button--disabled"
             >
+              Clear Previous Observations
+            </button>
           </div>
           <div class="input-group input-group-full">
-            <calcite-input
+            <input
               id="expressionFilter"
+              class="esri-input"
               type="text"
               placeholder="Attribute Filter (where clause)"
-            >
-              <calcite-button id="applyWhereClause" slot="action"
-                >Apply</calcite-button
-              >
-            </calcite-input>
+            />
+            <button id="applyWhereClause" class="esri-button">Apply</button>
           </div>
           <div class="input-group">
             <div class="input-row">
-              <calcite-button id="applySpatialFilter" class="prev-element"
-                >Apply Spatial Filter</calcite-button
+              <button id="applySpatialFilter" class="prev-element esri-button">
+                Apply Spatial Filter
+              </button>
+              <button
+                id="clearSpatialFilter"
+                class="esri-button esri-button--disabled"
               >
-              <calcite-button id="clearSpatialFilter" disabled="true"
-                >Clear Spatial Filter</calcite-button
-              >
+                Clear Spatial Filter
+              </button>
             </div>
           </div>
         </div>
       </section>
-      <calcite-button
-        id="switchViewer"
-        style="position: absolute; bottom: 0; right: 0; z-index: 1; margin: 5px;"
-        >Switch to Current Viewer</calcite-button
+      <section
+        style="position: absolute; bottom: 0; right: 0; padding: 5px 10px"
       >
+        <button id="switchViewer" class="esri-button">
+          Switch to Current Viewer
+        </button>
+      </section>
     </div>
   </body>
 </html>

--- a/classicViewer.html
+++ b/classicViewer.html
@@ -3,11 +3,49 @@
   <head lang="en">
     <meta charset="UTF-8" />
     <title>Stream Service Viewer</title>
-    <!-- Gives us calcite based design - does not seem to interfere with the 3x css -->
-    <link
-      rel="stylesheet"
-      href="https://js.arcgis.com/4.25/esri/themes/light/main.css"
-    />
+    <style>
+      .esri-button {
+        align-items:center;
+        background-color:#0079c1;
+        border:1px solid #0079c1;
+        color:#fff;
+        cursor:pointer;
+        display:flex;
+        font-family:inherit;
+        font-size:14px;
+        min-height:32px;
+        justify-content:center;
+        word-break:normal;
+        white-space:normal;
+        overflow:hidden;
+        padding:6px 7px;
+        width:100%;
+        transition:background-color 125ms ease-in-out,border 125ms ease-in-out
+      }
+
+      .esri-button:hover {
+        background-color:#00598e;
+        border:1px solid #00598e;
+        color:#fff
+      }
+
+      .esri-button--disabled {
+        opacity:.4;
+        pointer-events:none
+      }
+
+      .esri-input {
+        background-color:#fff;
+        border:1px solid #959595;
+        color:#323232;
+        font-family:"Avenir Next","Helvetica Neue",Helvetica,Arial,sans-serif;
+        font-size:14px
+      }
+      .esri-input[type=text] {
+        height:32px;
+        padding:0 .5em
+      }
+    </style>
     <link
       rel="stylesheet"
       href="https://js.arcgis.com/3.42/esri/css/esri.css"
@@ -103,10 +141,13 @@
             spatialFilter = evt.geometry;
             drawSpatialFilter(spatialFilter);
             if (streamLayer) streamLayer.setGeometryDefinition(spatialFilter);
-            domAttr.remove(dojo.byId("clearSpatialFilter"), "disabled");
+            domClass.remove(dojo.byId("clearSpatialFilter"), "esri-button--disabled");
           });
           on(dojo.byId("switchViewer"), "click", function () {
             window.location.href = "./currentViewer.html";
+          });
+          on(dojo.byId("clear"), "click", function () {
+            dojo.byId("panelMessage").innerText = "";
           });
         }
 
@@ -120,6 +161,16 @@
             document.getElementsByTagName("body")[0],
             "panel-collapsed"
           );
+        }
+
+        function createToaster(message, type) {
+          const msg =
+            type === "success"
+              ? document.createTextNode("\u2713 " + message)
+              : document.createTextNode("\u2716 " + message);
+          const element = document.createElement("span");
+          element.appendChild(msg);
+          document.getElementById("panelMessage").prepend(element);
         }
 
         /*************************************************
@@ -163,7 +214,7 @@
             streamLayer.on("message", onMessage);
             streamLayer.on("connection-error", function () {
               removeStreamLayer();
-              alert("Error connecting to the Stream Service");
+              createToaster("Error connecting to the Stream Service", "error");
             });
 
             // Add popup template
@@ -234,13 +285,13 @@
 
         function onMessage(msg) {
           if (msg.error) {
-            alert(msg.error[0]);
+            createToaster(msg.error[0], "error");
           } else if (msg.filter) {
             if (
               msg.filter.hasOwnProperty("where") ||
               msg.filter.hasOwnProperty("geometry")
             ) {
-              alert(
+              createToaster(
                 "Successfully updated the filter. \nAttribute Filter: " +
                   (msg.filter.where || "") +
                   "\nSpatial Filter: " +
@@ -248,12 +299,14 @@
                     ? typeof msg.filter.geometry === "object"
                       ? JSON.stringify(msg.filter.geometry)
                       : msg.filter.geometry
-                    : "")
+                    : ""),
+                "success"
               );
             } else {
-              alert(
-                "Successfully updated the filter. \n\nAttribute Filter: \n Spatial Filter: "
-              );
+              createToaster(
+                "Successfully updated the filter. \n\nAttribute Filter: \nSpatial Filter: ",
+                "success"
+              );  
             }
           }
         }
@@ -377,7 +430,7 @@
             />
             <button id="applyWhereClause" class="esri-button">Apply</button>
           </div>
-          <div class="input-group">
+          <div class="input-group input-group-full">
             <div class="input-row">
               <button id="applySpatialFilter" class="prev-element esri-button">
                 Apply Spatial Filter
@@ -389,6 +442,14 @@
                 Clear Spatial Filter
               </button>
             </div>
+          </div>
+        </div>
+      </section>
+      <section>
+        <div class="config-content">
+          <div id="panelWrapper">
+            <h4 id="panelHeading">Messages <span id="clear">clear</span></h4>
+            <p id="panelMessage"></p>
           </div>
         </div>
       </section>

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -129,6 +129,11 @@
             .addEventListener("click", function () {
               window.location.href = "./classicViewer.html";
             });
+          document
+            .getElementById("clear")
+            .addEventListener("click", function () {
+              document.getElementById("panelMessage").innerText = "";
+            });
         }
 
         /*************************************************
@@ -140,6 +145,16 @@
           document
             .getElementsByTagName("body")[0]
             .classList.toggle("panel-collapsed");
+        }
+
+        function createToaster(message, type) {
+          const msg =
+            type === "success"
+              ? document.createTextNode("\u2713 " + message)
+              : document.createTextNode("\u2716 " + message);
+          const element = document.createElement("span");
+          element.appendChild(msg);
+          document.getElementById("panelMessage").appendChild(element);
         }
 
         /*************************************************
@@ -181,7 +196,7 @@
             });
             layerView.watch("connectionError", function (error) {
               removeStreamLayer();
-              alert("Error connecting to the Stream Service");
+              createToaster("Error connecting to the Stream Service", "error");
             });
 
             streamLayer.popupTemplate = streamLayer.createPopupTemplate();
@@ -226,13 +241,13 @@
 
         function onMessage(msg) {
           if (msg.error) {
-            alert(sg.error[0]);
+            createToaster(msg.error[0], "error");
           } else if (msg.filter) {
             if (
               msg.filter.hasOwnProperty("where") ||
               msg.filter.hasOwnProperty("geometry")
             ) {
-              alert(
+              createToaster(
                 "Successfully updated the filter. \nAttribute Filter: " +
                   (msg.filter.where || "") +
                   "\nSpatial Filter: " +
@@ -240,11 +255,13 @@
                     ? typeof msg.filter.geometry === "object"
                       ? JSON.stringify(msg.filter.geometry)
                       : msg.filter.geometry
-                    : "")
+                    : ""),
+                "success"
               );
             } else {
-              alert(
-                "Successfully updated the filter. \n\nAttribute Filter: \n Spatial Filter: "
+              createToaster(
+                "Successfully updated the filter. \n\nAttribute Filter: \nSpatial Filter: ",
+                "success"
               );
             }
           }
@@ -367,6 +384,14 @@
                 Clear Spatial Filter
               </button>
             </div>
+          </div>
+        </div>
+      </section>
+      <section>
+        <div class="config-content">
+          <div id="panelWrapper">
+            <h4 id="panelHeading">Messages <span id="clear">clear</span></h4>
+            <p id="panelMessage"></p>
           </div>
         </div>
       </section>

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -7,45 +7,31 @@
       rel="stylesheet"
       href="https://js.arcgis.com/4.25/esri/themes/light/main.css"
     />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://js.arcgis.com/calcite-components/1.0.0-beta.97/calcite.css"
-    />
     <link rel="stylesheet" href="./streamServiceViewerStyles.css" />
     <script src="https://js.arcgis.com/4.25/"></script>
-    <script src="https://use.fontawesome.com/9482a0b1d1.js"></script>
-    <script
-      type="module"
-      src="https://js.arcgis.com/calcite-components/1.0.0-beta.97/calcite.esm.js"
-    ></script>
     <script>
       require([
         "esri/Map",
         "esri/views/MapView",
         "esri/widgets/BasemapGallery",
         "esri/layers/StreamLayer",
-        "esri/geometry/Polygon",
         "esri/Graphic",
         "esri/PopupTemplate",
-        "esri/popup/FieldInfo",
         "esri/widgets/Sketch/SketchViewModel",
         "esri/layers/GraphicsLayer",
         "esri/widgets/Expand"
-      ], function(
+      ], function (
         Map,
         MapView,
         BasemapGallery,
         StreamLayer,
-        Polygon,
         Graphic,
         PopupTemplate,
-        FieldInfo,
         SketchViewModel,
         GraphicsLayer,
         Expand
       ) {
-        var map,
+        let map,
           mapView,
           sketchViewModel,
           sketchViewModelLayer,
@@ -63,7 +49,7 @@
             container: "map"
           });
 
-          var bgExpand = new Expand({
+          const bgExpand = new Expand({
             view: mapView,
             content: new BasemapGallery({ view: mapView })
           });
@@ -81,7 +67,7 @@
             }
           });
 
-          sketchViewModel.on("create", function(obj) {
+          sketchViewModel.on("create", function (obj) {
             switch (obj.state) {
               case "complete":
                 spatialFilter = obj.graphic.geometry.extent;
@@ -89,7 +75,7 @@
                 if (streamLayer) streamLayer.geometryDefinition = spatialFilter;
                 document
                   .getElementById("clearSpatialFilter")
-                  .removeAttribute("disabled");
+                  .classList.remove("esri-button--disabled");
                 break;
               default:
                 break;
@@ -97,11 +83,12 @@
           });
 
           //connect click events to UI buttons
-          var headerElements = document.getElementsByClassName("config-header");
-          for (var i = 0; i < headerElements.length; i++) {
-            headerElements[i].addEventListener("click", function(e) {
+          const headerElements =
+            document.getElementsByClassName("config-header");
+          for (let i = 0; i < headerElements.length; i++) {
+            headerElements[i].addEventListener("click", function (e) {
               if (e.target.type !== "checkbox") {
-                var sectionWrapper = e.target.closest("section");
+                const sectionWrapper = e.target.closest("section");
                 sectionWrapper.classList.toggle("section-hidden");
               }
             });
@@ -139,25 +126,6 @@
             .classList.toggle("panel-collapsed");
         }
 
-        function createToaster(title, message, color) {
-          var calciteAlert = document.createElement("calcite-alert");
-          var alertTitle = document.createElement("div");
-          var alertMessage = document.createElement("div");
-
-          calciteAlert.setAttribute("open", "true");
-          calciteAlert.setAttribute("color", color);
-          calciteAlert.setAttribute("placement", "bottom-end");
-          alertTitle.setAttribute("slot", "title");
-          alertMessage.setAttribute("slot", "message");
-
-          alertTitle.innerText = title;
-          alertMessage.innerText = message;
-
-          calciteAlert.appendChild(alertTitle);
-          calciteAlert.appendChild(alertMessage);
-          document.getElementsByTagName("body")[0].appendChild(calciteAlert);
-        }
-
         /*************************************************
          *
          * Functions to add and remove Stream Layer
@@ -169,7 +137,7 @@
 
         function addStreamLayer() {
           //url to stream service
-          var svcUrl = document.getElementById("streamServiceUrl").value;
+          const svcUrl = document.getElementById("streamServiceUrl").value;
 
           //construct Stream Layer
           streamLayer = new StreamLayer({
@@ -185,23 +153,19 @@
           map.add(streamLayer);
 
           //When layer loads, register listeners for layer events and add layer to map
-          mapView.whenLayerView(streamLayer).then(function(layerView) {
+          mapView.whenLayerView(streamLayer).then(function (layerView) {
             onLayerAdded();
 
-            layerView.watch("connectionStatus", function(value) {
+            layerView.watch("connectionStatus", function (value) {
               if (value === "connected") {
                 onLayerAdded();
               } else {
                 onLayerRemoved();
               }
             });
-            layerView.watch("connectionError", function(error) {
-              createToaster(
-                "Alert",
-                "Error connecting to the Stream Service",
-                "red"
-              );
+            layerView.watch("connectionError", function (error) {
               removeStreamLayer();
+              alert("Error connecting to the Stream Service");
             });
 
             streamLayer.popupTemplate = streamLayer.createPopupTemplate();
@@ -227,10 +191,10 @@
             "Remove Stream Layer";
           document
             .getElementById("subscribeUnsubscribe")
-            .removeAttribute("disabled");
+            .classList.remove("esri-button--disabled");
           document
             .getElementById("clearPreviousObservations")
-            .removeAttribute("disabled");
+            .classList.remove("esri-button-disabled");
         }
 
         function onLayerRemoved() {
@@ -238,51 +202,14 @@
             "Add Stream Layer";
           document
             .getElementById("subscribeUnsubscribe")
-            .setAttribute("disabled", "true");
+            .classList.add("esri-button--disabled");
           document
             .getElementById("clearPreviousObservations")
-            .setAttribute("disabled", "true");
-          // enable necessary buttons
-          if (spatialFilter)
-            document
-              .getElementById("clearSpatialFilter")
-              .removeAttribute("disabled");
-          document
-            .getElementById("applySpatialFilter")
-            .removeAttribute("disabled");
-          document
-            .getElementById("applyWhereClause")
-            .removeAttribute("disabled");
+            .classList.add("esri-button--disabled");
         }
 
         function onMessage(msg) {
-          if (msg.error) {
-            createToaster("Alert", msg.error[0], "red");
-          } else if (msg.filter) {
-            if (
-              msg.filter.hasOwnProperty("where") ||
-              msg.filter.hasOwnProperty("geometry")
-            ) {
-              createToaster(
-                "Success",
-                "Successfully updated the filter. \nAttribute Filter: " +
-                  (msg.filter.where || "") +
-                  "\nSpatial Filter: " +
-                  (msg.filter.geometry
-                    ? typeof msg.filter.geometry === "object"
-                      ? JSON.stringify(msg.filter.geometry)
-                      : msg.filter.geometry
-                    : ""),
-                "green"
-              );
-            } else {
-              createToaster(
-                "Success",
-                "Successfully updated the filter. \n\nAttribute Filter: \n Spatial Filter: ",
-                "green"
-              );
-            }
-          }
+          if (msg.error) alert(msg.error[0]);
         }
 
         /************************************************
@@ -306,7 +233,7 @@
           if (streamLayer) streamLayer.geometryDefinition = null;
           document
             .getElementById("clearSpatialFilter")
-            .setAttribute("disabled", "true");
+            .classList.add("esri-button--disabled");
         }
 
         function drawSpatialFilter(geometry) {
@@ -333,7 +260,6 @@
       });
     </script>
   </head>
-
   <body class="flat">
     <div id="map"></div>
     <div class="collapser">
@@ -345,85 +271,74 @@
         <div class="config-header">
           <h2>Layers</h2>
           <div class="header-actions-group">
-            <i class="fa"></i>
+            <i id="collapsedPane" class="fa flat-chevron-down"></i>
+            <i id="expandedPane" class="fa flat-chevron-up"></i>
           </div>
         </div>
         <div class="config-content">
-          <div class="input-group input-group-full">
-            <calcite-input
+          <div class="input-group input-group-full input-group-flex">
+            <input
               type="text"
               id="streamServiceUrl"
+              class="esri-input"
               placeholder="Stream layer url"
-              value="https://geoeventsample1.esri.com/server/rest/services/FAAStream/StreamServer"
-            ></calcite-input>
+              value="https:/geoeventsample1.esri.com/server/rest/services/FAAStream/StreamServer"
+            />
           </div>
           <div class="input-group input-group-full">
-            <calcite-button id="toggleStreamLayer" width="full"
-              >Add Stream Layer</calcite-button
-            >
+            <button id="toggleStreamLayer" class="esri-button">
+              Add Stream Layer
+            </button>
           </div>
           <div class="input-group input-group-full">
-            <calcite-tooltip
-              label="This feature is currently unavailable with the current version of the JSAPI"
-              reference-element="subscribeUnsubscribe"
-            >
-              <span
-                >This feature is currently unavailable with the current version
-                of the JSAPI</span
-              >
-            </calcite-tooltip>
-            <calcite-button
+            <button
               id="subscribeUnsubscribe"
-              width="full"
-              disabled="true"
-              >Unsubscribe</calcite-button
+              class="esri-button esri-button--disabled"
+              title="This feature is currently unavailable with the current version of the JSAPI"
             >
+              Unsubscribe
+            </button>
           </div>
           <div class="input-group input-group-full">
-            <calcite-tooltip
-              label="This feature is currently unavailable with the current version of the JSAPI"
-              reference-element="clearPreviousObservations"
-            >
-              <span
-                >This feature is currently unavailable with the current version
-                of the JSAPI</span
-              >
-            </calcite-tooltip>
-            <calcite-button
+            <button
               id="clearPreviousObservations"
-              width="full"
-              disabled="true"
-              >Clear Previous Observations</calcite-button
+              class="esri-button esri-button--disabled"
+              title="This feature is currently unavailable with the current version of the JSAPI"
             >
+              Clear Previous Observations
+            </button>
           </div>
-          <div class="input-group input-group-full">
-            <calcite-input
+          <div class="input-group input-group-full input-group-flex">
+            <input
               id="expressionFilter"
+              class="esri-input"
               type="text"
               placeholder="Attribute Filter (where clause)"
-            >
-              <calcite-button id="applyWhereClause" slot="action"
-                >Apply</calcite-button
-              >
-            </calcite-input>
+            />
+            <button id="applyWhereClause" class="esri-button">Apply</button>
           </div>
           <div class="input-group">
             <div class="input-row">
-              <calcite-button id="applySpatialFilter" class="prev-element"
-                >Apply Spatial Filter</calcite-button
+              <button id="applySpatialFilter" class="prev-element esri-button">
+                Apply Spatial Filter
+              </button>
+              <button
+                id="clearSpatialFilter"
+                class="esri-button esri-button--disabled"
               >
-              <calcite-button id="clearSpatialFilter" disabled="true"
-                >Clear Spatial Filter</calcite-button
-              >
+                Clear Spatial Filter
+              </button>
             </div>
           </div>
         </div>
       </section>
-      <calcite-button
-        id="switchViewer"
-        style="position: absolute; bottom: 0; right: 0; z-index: 1; margin: 5px;"
-        >Switch to Classic Viewer</calcite-button
+      <section
+        style="position: absolute; bottom: 0; right: 0; padding: 5px 10px"
       >
+        <button id="switchViewer" class="esri-button">
+          Switch to Classic Viewer
+        </button>
+      </section>
     </div>
   </body>
 </html>

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -19,7 +19,9 @@
         "esri/PopupTemplate",
         "esri/widgets/Sketch/SketchViewModel",
         "esri/layers/GraphicsLayer",
-        "esri/widgets/Expand"
+        "esri/widgets/Expand",
+        "esri/widgets/LayerList",
+        "esri/widgets/Legend"
       ], function (
         Map,
         MapView,
@@ -29,7 +31,9 @@
         PopupTemplate,
         SketchViewModel,
         GraphicsLayer,
-        Expand
+        Expand,
+        LayerList,
+        Legend
       ) {
         let map,
           mapView,
@@ -53,7 +57,19 @@
             view: mapView,
             content: new BasemapGallery({ view: mapView })
           });
+          const layerListExpand = new Expand({
+            view: mapView,
+            content: new LayerList({ view: mapView }),
+            expanded: false
+          });
+          const legendExpand = new Expand({
+            view: mapView,
+            content: new Legend({ view: mapView })
+          });
+
           mapView.ui.add(bgExpand, "top-left");
+          mapView.ui.add(layerListExpand, "top-right");
+          mapView.ui.add(legendExpand, "bottom-left");
 
           sketchViewModelLayer = new GraphicsLayer();
           map.add(sketchViewModelLayer);

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -110,7 +110,7 @@
             .addEventListener("click", clearSpatialFilter);
           document
             .getElementById("switchViewer")
-            .addEventListener("click", function() {
+            .addEventListener("click", function () {
               window.location.href = "./classicViewer.html";
             });
         }
@@ -209,7 +209,29 @@
         }
 
         function onMessage(msg) {
-          if (msg.error) alert(msg.error[0]);
+          if (msg.error) {
+            alert(sg.error[0]);
+          } else if (msg.filter) {
+            if (
+              msg.filter.hasOwnProperty("where") ||
+              msg.filter.hasOwnProperty("geometry")
+            ) {
+              alert(
+                "Successfully updated the filter. \nAttribute Filter: " +
+                  (msg.filter.where || "") +
+                  "\nSpatial Filter: " +
+                  (msg.filter.geometry
+                    ? typeof msg.filter.geometry === "object"
+                      ? JSON.stringify(msg.filter.geometry)
+                      : msg.filter.geometry
+                    : "")
+              );
+            } else {
+              alert(
+                "Successfully updated the filter. \n\nAttribute Filter: \n Spatial Filter: "
+              );
+            }
+          }
         }
 
         /************************************************

--- a/streamServiceViewerStyles.css
+++ b/streamServiceViewerStyles.css
@@ -81,6 +81,10 @@ body {
   right: 0;
 }
 
+#collapsedPane {
+  display: none;
+}
+
 #expanderIcon {
   display: none;
 }
@@ -154,12 +158,20 @@ section:first-of-type .config-header {
   color: #a6a6a6;
 }
 
-.header-actions-group .fa::before {
-  content: "\f077";
+.header-actions-group #expandedPane {
+  display: inline-block;
 }
 
-.section-hidden .header-actions-group .fa::before {
-  content: "\f078";
+.header-actions-group i {
+  font-size: 1.4em;
+}
+
+.section-hidden .header-actions-group #expandedPane {
+  display: none;
+}
+
+.section-hidden .header-actions-group #collapsedPane {
+  display: inline-block;
 }
 
 .header-actions-group i:hover {
@@ -192,8 +204,24 @@ section:first-of-type .config-header {
   width: 100%;
 }
 
+.input-group-flex {
+  display: flex;
+}
+
+#streamServiceUrl {
+  flex-basis: 100%;
+}
+
+#expressionFilter {
+  flex-grow: 2;
+}
+
+#applyWhereClause {
+  width: 25%;
+}
+
 .prev-element {
-  margin-right: 5px;
+  margin-right: 10px;
 }
 
 .flat .dijitDropDownButton .dijitButtonNode {

--- a/streamServiceViewerStyles.css
+++ b/streamServiceViewerStyles.css
@@ -261,3 +261,7 @@ section:first-of-type .config-header {
   justify-content: space-between;
   width: 250px;
 }
+
+.esri-ui-top-right {
+  margin-right: 40px;
+}

--- a/streamServiceViewerStyles.css
+++ b/streamServiceViewerStyles.css
@@ -265,3 +265,36 @@ section:first-of-type .config-header {
 .esri-ui-top-right {
   margin-right: 40px;
 }
+
+#panelWrapper {
+  background-color: white;
+  border: 1px solid gray;
+  width: 100%;
+  padding-left: 10px;
+  min-height: 450px;
+  max-height: 450px;
+  overflow-wrap: anywhere;
+}
+
+#panelHeading {
+  margin-top: 10px;
+}
+
+#panelMessage {
+  overflow: scroll;
+  height: 380px;
+  margin-top: 0;
+}
+
+#panelMessage span {
+  display: block;
+  margin-top: 10px;
+}
+
+#clear {
+  font-style: italic;
+  font-size: small;
+  right: 20px;
+  cursor: pointer;
+  position: absolute;
+}


### PR DESCRIPTION
Cleaning up the code to include the following:
- Uses of `var` are switched to `let` or `const`
- Removing calcite scripts and css as well as fontawesome
- Adding `Legend` and `LayerList` widgets to the current viewer
- Removing unused imports