### PR TITLE
Migrate to JSAPI 4.29 and Add Connect/Disconnect functionality

### DIFF
--- a/classicViewer.html
+++ b/classicViewer.html
@@ -272,7 +272,7 @@
             dojo.byId("clearPreviousObservations"),
             "esri-button--disabled"
           );
-          dojo.byId("subscribeUnsubscribe").innerText = "Unsubscribe";
+          dojo.byId("subscribeUnsubscribe").innerText = "Disconnect";
           domClass.add(
             dojo.byId("subscribeUnsubscribe"),
             "esri-button--disabled"
@@ -280,11 +280,11 @@
         }
 
         function onLayerConnected() {
-          dojo.byId("subscribeUnsubscribe").innerText = "Unsubscribe";
+          dojo.byId("subscribeUnsubscribe").innerText = "Disconnect";
         }
 
         function onLayerDisconnected() {
-          dojo.byId("subscribeUnsubscribe").innerText = "Subscribe";
+          dojo.byId("subscribeUnsubscribe").innerText = "Connect";
         }
 
         function onMessage(msg) {
@@ -414,7 +414,7 @@
               id="subscribeUnsubscribe"
               class="esri-button esri-button--disabled"
             >
-              Unsubscribe
+              Disconnect
             </button>
           </div>
           <div class="input-group input-group-full">

--- a/classicViewer.html
+++ b/classicViewer.html
@@ -129,7 +129,7 @@
             "click",
             togglePanel
           );
-          on(dojo.byId("subscribeUnsubscribe"), "click", toggleSubscription);
+          on(dojo.byId("connectDisconnect"), "click", toggleSubscription);
           on(dojo.byId("toggleStreamLayer"), "click", toggleStreamLayer);
           on(dojo.byId("clearPreviousObservations"), "click", function () {
             if (streamLayer) streamLayer.clear();
@@ -260,7 +260,7 @@
               "esri-button--disabled"
             );
             domClass.remove(
-              dojo.byId("subscribeUnsubscribe"),
+              dojo.byId("connectDisconnect"),
               "esri-button--disabled"
             );
           }
@@ -272,19 +272,19 @@
             dojo.byId("clearPreviousObservations"),
             "esri-button--disabled"
           );
-          dojo.byId("subscribeUnsubscribe").innerText = "Disconnect";
+          dojo.byId("connectDisconnect").innerText = "Disconnect";
           domClass.add(
-            dojo.byId("subscribeUnsubscribe"),
+            dojo.byId("connectDisconnect"),
             "esri-button--disabled"
           );
         }
 
         function onLayerConnected() {
-          dojo.byId("subscribeUnsubscribe").innerText = "Disconnect";
+          dojo.byId("connectDisconnect").innerText = "Disconnect";
         }
 
         function onLayerDisconnected() {
-          dojo.byId("subscribeUnsubscribe").innerText = "Connect";
+          dojo.byId("connectDisconnect").innerText = "Connect";
         }
 
         function onMessage(msg) {
@@ -411,7 +411,7 @@
           </div>
           <div class="input-group input-group-full">
             <button
-              id="subscribeUnsubscribe"
+              id="connectDisconnect"
               class="esri-button esri-button--disabled"
             >
               Disconnect

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -198,9 +198,16 @@
             if (streamLayerView.connectionStatus === "disconnected") {
               streamLayerView.connect();
               document.getElementById("connectDisconnect").innerText = "Disconnect";
+
+              document.getElementById("clearPreviousObservations")
+                .classList.remove("esri-button--disabled")
             } else {
               streamLayerView.disconnect();
               document.getElementById("connectDisconnect").innerText = "Connect";
+
+              // Previous observations cannot be cleared when disconnected.
+              document.getElementById("clearPreviousObservations")
+                .classList.add("esri-button--disabled")
             }
           }
         }

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -117,7 +117,7 @@
             .getElementById("toggleStreamLayer")
             .addEventListener("click", toggleStreamLayer);
           document
-            .getElementById("subscribeUnsubscribe")
+            .getElementById("pauseResume")
             .addEventListener("click", toggleSubscription);
           document
             .getElementById("applyWhereClause")
@@ -184,12 +184,12 @@
             streamLayerView.connectionStatus === "paused"
           ) {
             streamLayerView.resume();
-            document.getElementById("subscribeUnsubscribe").innerText =
-              "Unsubscribe";
+            document.getElementById("pauseResume").innerText =
+              "Pause";
           } else {
             streamLayerView.pause();
-            document.getElementById("subscribeUnsubscribe").innerText =
-              "Subscribe";
+            document.getElementById("pauseResume").innerText =
+              "Resume";
           }
         }
 
@@ -203,9 +203,9 @@
               document.getElementById("clearPreviousObservations")
                 .classList.remove("esri-button--disabled")
 
-              document.getElementById("subscribeUnsubscribe").innerText =
-                "Unsubscribe";
-              document.getElementById("subscribeUnsubscribe")
+              document.getElementById("pauseResume").innerText =
+                "Pause";
+              document.getElementById("pauseResume")
                 .classList.remove("esri-button--disabled");
             } else {
               streamLayerView.disconnect();
@@ -219,9 +219,9 @@
               // Pausing / resuming a disconnected stream layer has no effect,
               // so we'll disable the button and set it up so the user can
               // subscribe again
-              document.getElementById("subscribeUnsubscribe").innerText =
-                "Subscribe";
-              document.getElementById("subscribeUnsubscribe")
+              document.getElementById("pauseResume").innerText =
+                "Resume";
+              document.getElementById("pauseResume")
                 .classList.add("esri-button--disabled");
             }
           }
@@ -281,7 +281,7 @@
           document.getElementById("toggleStreamLayer").innerText =
             "Remove Stream Layer";
           document
-            .getElementById("subscribeUnsubscribe")
+            .getElementById("pauseResume")
             .classList.remove("esri-button--disabled");
           document
             .getElementById("clearPreviousObservations")
@@ -294,10 +294,10 @@
           document.getElementById("toggleStreamLayer").innerText =
             "Add Stream Layer";
           document
-            .getElementById("subscribeUnsubscribe")
+            .getElementById("pauseResume")
             .classList.add("esri-button--disabled");
-          document.getElementById("subscribeUnsubscribe").innerText =
-            "Unsubscribe";
+          document.getElementById("pauseResume").innerText =
+            "Pause";
           document
             .getElementById("clearPreviousObservations")
             .classList.add("esri-button--disabled");
@@ -433,10 +433,10 @@
           </div>
           <div class="input-group input-group-full">
             <button
-              id="subscribeUnsubscribe"
+              id="pauseResume"
               class="esri-button esri-button--disabled"
             >
-              Unsubscribe
+              Pause
             </button>
           </div>
           <div class="input-group input-group-full">

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -129,6 +129,9 @@
             .getElementById("clearSpatialFilter")
             .addEventListener("click", clearSpatialFilter);
           document
+            .getElementById("connectDisconnect")
+            .addEventListener("click", toggleConnection);
+          document
             .getElementById("clearPreviousObservations")
             .addEventListener("click", function () {
               if (streamLayer) {
@@ -187,6 +190,18 @@
             streamLayerView.pause();
             document.getElementById("subscribeUnsubscribe").innerText =
               "Subscribe";
+          }
+        }
+
+        function toggleConnection() {
+          if (streamLayerView) {
+            if (streamLayerView.connectionStatus === "disconnected") {
+              streamLayerView.connect();
+              document.getElementById("connectDisconnect").innerText = "Disconnect";
+            } else {
+              streamLayerView.disconnect();
+              document.getElementById("connectDisconnect").innerText = "Connect";
+            }
           }
         }
 

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -189,10 +189,14 @@
             streamLayerView.resume();
             document.getElementById("pauseResume").innerText =
               "Pause";
+            document.getElementById("pauseResume").title =
+              "Pause the connection to stop new observations from being applied until resuming. Data will be received but will not update the layer view until resumed.";
           } else {
             streamLayerView.pause();
             document.getElementById("pauseResume").innerText =
               "Resume";
+            document.getElementById("pauseResume").title =
+              "Resume the connection, apply any observations received while paused, and update the layer view with new observations.";
           }
         }
 
@@ -217,6 +221,8 @@
               streamLayerView.disconnect();
               document.getElementById("connectDisconnect").innerText =
                 "Connect";
+              document.getElementById("connectDisconnect").title =
+                "Connect to the stream service to stream new observations.";
 
               // Previous observations cannot be cleared when disconnected.
               document.getElementById("clearPreviousObservations")
@@ -304,18 +310,25 @@
         function onLayerRemoved() {
           document.getElementById("toggleStreamLayer").innerText =
             "Add Stream Layer";
+
           document
             .getElementById("pauseResume")
             .classList.add("esri-button--disabled");
           document.getElementById("pauseResume").innerText =
             "Pause";
+          document.getElementById("pauseResume").title =
+            "Pause the connection to stop new observations from being applied until resuming. Data will be received but will not update the layer view until resumed.";
+
           document
             .getElementById("clearPreviousObservations")
             .classList.add("esri-button--disabled");
+
           document.getElementById("connectDisconnect")
             .classList.add("esri-button--disabled");
           document.getElementById("connectDisconnect").innerText = 
             "Disconnect";
+          document.getElementById("connectDisconnect").title =
+            "Disconnect from the stream service. New observations will not be streamed until reconnecting.";
         }
 
         function onMessage(msg) {
@@ -355,6 +368,8 @@
           if (isConnectingFromConnectCall && connectionStatus === "connected") {
             document.getElementById("connectDisconnect").innerText =
               "Disconnect";
+            document.getElementById("connectDisconnect").title =
+              "Disconnect from the stream service. New observations will not be streamed until reconnecting.";
             document.getElementById("connectDisconnect")
               .classList.remove("esri-button--disabled");
 
@@ -363,6 +378,8 @@
 
             document.getElementById("pauseResume").innerText =
               "Pause";
+            document.getElementById("pauseResume").title =
+              "Pause the connection to stop new observations from being applied until resuming. Data will be received but will not update the layer view until resumed.";
             document.getElementById("pauseResume")
               .classList.remove("esri-button--disabled");
 
@@ -462,7 +479,11 @@
             </button>
           </div>
           <div class="input-group input-group-full">
-            <button id="connectDisconnect" class="esri-button esri-button--disabled">
+            <button
+              id="connectDisconnect"
+              class="esri-button esri-button--disabled"
+              title="Disconnect from the stream service. New observations will not be streamed until reconnecting."
+            >
               Disconnect
             </button>
           </div>
@@ -470,6 +491,7 @@
             <button
               id="pauseResume"
               class="esri-button esri-button--disabled"
+              title="Pause the connection to stop new observations from being applied until resuming. Data will be received but will not update the layer view until resumed."
             >
               Pause
             </button>

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -249,6 +249,8 @@
           document
             .getElementById("clearPreviousObservations")
             .classList.remove("esri-button--disabled");
+          document.getElementById("connectDisconnect")
+            .classList.remove("esri-button--disabled");
         }
 
         function onLayerRemoved() {
@@ -262,6 +264,10 @@
           document
             .getElementById("clearPreviousObservations")
             .classList.add("esri-button--disabled");
+          document.getElementById("connectDisconnect")
+            .classList.add("esri-button--disabled");
+          document.getElementById("connectDisconnect").innerText = 
+            "Disconnect";
         }
 
         function onMessage(msg) {
@@ -381,6 +387,11 @@
           <div class="input-group input-group-full">
             <button id="toggleStreamLayer" class="esri-button">
               Add Stream Layer
+            </button>
+          </div>
+          <div class="input-group input-group-full">
+            <button id="connectDisconnect" class="esri-button esri-button--disabled">
+              Disconnect
             </button>
           </div>
           <div class="input-group input-group-full">

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -393,17 +393,35 @@
         function applyWhereClause() {
           expressionFilter = document.getElementById("expressionFilter").value;
           if (streamLayer) {
-            streamLayer.sendMessageToSocket({
-              filter: { where: expressionFilter }
-            });
+            if (document.getElementById("useWebsocketMessage").checked) {
+              streamLayer.sendMessageToSocket({
+                filter: { where: expressionFilter }
+              });
+            } else {
+              streamLayer.definitionExpression = expressionFilter;
+
+              createToaster(
+                "Successfully updated the filter. \nAttribute Filter: " + expressionFilter,
+                "success"
+              );
+            }
           }
         }
 
         function applySpatialFilter(geometry) {
           if (streamLayer) {
-            streamLayer.sendMessageToSocket({
-              filter: { geometry: JSON.stringify(geometry) }
-            });
+            if (document.getElementById("useWebsocketMessage").checked) {
+              streamLayer.sendMessageToSocket({
+                filter: { geometry: JSON.stringify(geometry) }
+              });
+            } else {
+              streamLayer.geometryDefinition = geometry;
+
+              createToaster(
+                "Successfully updated the filter. \nSpatial Filter: " + JSON.stringify(geometry),
+                "success"
+              );
+            }
           }
         }
 
@@ -415,7 +433,16 @@
           spatialFilter = null;
           sketchViewModelLayer.removeAll();
           if (streamLayer) {
-            streamLayer.sendMessageToSocket({ filter: { geometry: null } });
+            if (document.getElementById("useWebsocketMessage").checked) {
+              streamLayer.sendMessageToSocket({ filter: { geometry: null } });
+            } else {
+              streamLayer.geometryDefinition = null;
+
+              createToaster(
+                "Successfully updated the filter. \nSpatial Filter: ",
+                "success"
+              );
+            }
           }
           disableButton("clearSpatialFilter");
         }
@@ -521,6 +548,14 @@
                 Clear Spatial Filter
               </button>
             </div>
+          </div>
+          <div class="input-group input-group-full">
+            <input
+              id="useWebsocketMessage"
+              class="esri-input"
+              type="checkbox"
+            />
+            <label for="useWebsocketMessage">Use websocket messages</label>
           </div>
         </div>
       </section>

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -399,7 +399,9 @@
               });
             } else {
               streamLayer.definitionExpression = expressionFilter;
-
+              // Adding the "toaster" line message explicitly is required for this case,
+              // since there will be no websocket message-received event fired, as opposed to the
+              // sendMessageToSocket case.
               createToaster(
                 "Successfully updated the filter. \nAttribute Filter: " + expressionFilter,
                 "success"
@@ -416,7 +418,9 @@
               });
             } else {
               streamLayer.geometryDefinition = geometry;
-
+              // Adding the "toaster" line message explicitly is required for this case,
+              // since there will be no websocket message-received event fired, as opposed to the
+              // sendMessageToSocket case.
               createToaster(
                 "Successfully updated the filter. \nSpatial Filter: " + JSON.stringify(geometry),
                 "success"
@@ -437,7 +441,9 @@
               streamLayer.sendMessageToSocket({ filter: { geometry: null } });
             } else {
               streamLayer.geometryDefinition = null;
-
+              // Adding the "toaster" line message explicitly is required for this case,
+              // since there will be no websocket message-received event fired, as opposed to the
+              // sendMessageToSocket case.
               createToaster(
                 "Successfully updated the filter. \nSpatial Filter: ",
                 "success"

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -93,9 +93,7 @@
                 spatialFilter = obj.graphic.geometry.extent;
                 drawSpatialFilter(spatialFilter);
                 applySpatialFilter(spatialFilter);
-                document
-                  .getElementById("clearSpatialFilter")
-                  .classList.remove("esri-button--disabled");
+                enableButton("clearSpatialFilter");
                 break;
               default:
                 break;
@@ -176,6 +174,44 @@
           document.getElementById("panelMessage").prepend(element);
         }
 
+        function setPauseResumeButtonToPause() {
+          document.getElementById("pauseResume").innerText =
+            "Pause";
+          document.getElementById("pauseResume").title =
+            "Pause the connection to stop new observations from being applied until resuming. Data will be received but will not update the layer view until resumed.";
+        }
+
+        function setPauseResumeButtonToResume() {
+          document.getElementById("pauseResume").innerText =
+            "Resume";
+          document.getElementById("pauseResume").title =
+            "Resume the connection, apply any observations received while paused, and update the layer view with new observations.";
+        } 
+
+        function setConnectDisconnectButtonToConnect() {
+          document.getElementById("connectDisconnect").innerText =
+            "Connect";
+          document.getElementById("connectDisconnect").title =
+            "Connect to the stream service to stream new observations.";
+        }
+
+        function setConnectDisconnectButtonToDisconnect() {
+          document.getElementById("connectDisconnect").innerText = 
+            "Disconnect";
+          document.getElementById("connectDisconnect").title =
+            "Disconnect from the stream service. New observations will not be streamed until reconnecting.";
+        }
+
+        function disableButton(buttonId) {
+          document.getElementById(buttonId)
+            .classList.add("esri-button--disabled");
+        }
+
+        function enableButton(buttonId) {
+          document.getElementById(buttonId)
+            .classList.remove("esri-button--disabled");
+        }
+
         /*************************************************
          *
          * Functions to add and remove Stream Layer
@@ -187,16 +223,10 @@
             streamLayerView.connectionStatus === "paused"
           ) {
             streamLayerView.resume();
-            document.getElementById("pauseResume").innerText =
-              "Pause";
-            document.getElementById("pauseResume").title =
-              "Pause the connection to stop new observations from being applied until resuming. Data will be received but will not update the layer view until resumed.";
+            setPauseResumeButtonToPause();
           } else {
             streamLayerView.pause();
-            document.getElementById("pauseResume").innerText =
-              "Resume";
-            document.getElementById("pauseResume").title =
-              "Resume the connection, apply any observations received while paused, and update the layer view with new observations.";
+            setPauseResumeButtonToResume();
           }
         }
 
@@ -213,28 +243,21 @@
               */
               document.getElementById("connectDisconnect").innerText =
                     "Connecting";
-                  document.getElementById("connectDisconnect")
-                    .classList.add("esri-button--disabled");
+              disableButton("connectDisconnect");
 
               isConnectingFromConnectCall = true;
             } else {
               streamLayerView.disconnect();
-              document.getElementById("connectDisconnect").innerText =
-                "Connect";
-              document.getElementById("connectDisconnect").title =
-                "Connect to the stream service to stream new observations.";
+              setConnectDisconnectButtonToConnect();
 
               // Previous observations cannot be cleared when disconnected.
-              document.getElementById("clearPreviousObservations")
-                .classList.add("esri-button--disabled")
+              disableButton("clearPreviousObservations");
 
               // Pausing / resuming a disconnected stream layer has no effect,
-              // so we'll disable the button and set it up so the user can
+              // so, disable the button and set it up so the user can
               // subscribe again
-              document.getElementById("pauseResume").innerText =
-                "Resume";
-              document.getElementById("pauseResume")
-                .classList.add("esri-button--disabled");
+              setPauseResumeButtonToResume();
+              disableButton("pauseResume");
             }
           }
         }
@@ -297,38 +320,22 @@
         function onLayerAdded() {
           document.getElementById("toggleStreamLayer").innerText =
             "Remove Stream Layer";
-          document
-            .getElementById("pauseResume")
-            .classList.remove("esri-button--disabled");
-          document
-            .getElementById("clearPreviousObservations")
-            .classList.remove("esri-button--disabled");
-          document.getElementById("connectDisconnect")
-            .classList.remove("esri-button--disabled");
+          enableButton("pauseResume");
+          enableButton("clearPreviousObservations");
+          enableButton("connectDisconnect");
         }
 
         function onLayerRemoved() {
           document.getElementById("toggleStreamLayer").innerText =
             "Add Stream Layer";
 
-          document
-            .getElementById("pauseResume")
-            .classList.add("esri-button--disabled");
-          document.getElementById("pauseResume").innerText =
-            "Pause";
-          document.getElementById("pauseResume").title =
-            "Pause the connection to stop new observations from being applied until resuming. Data will be received but will not update the layer view until resumed.";
+          disableButton("pauseResume");
+          setPauseResumeButtonToPause();
 
-          document
-            .getElementById("clearPreviousObservations")
-            .classList.add("esri-button--disabled");
+          disableButton("clearPreviousObservations");
 
-          document.getElementById("connectDisconnect")
-            .classList.add("esri-button--disabled");
-          document.getElementById("connectDisconnect").innerText = 
-            "Disconnect";
-          document.getElementById("connectDisconnect").title =
-            "Disconnect from the stream service. New observations will not be streamed until reconnecting.";
+          disableButton("connectDisconnect");
+          setConnectDisconnectButtonToDisconnect();
         }
 
         function onMessage(msg) {
@@ -366,22 +373,13 @@
           * disconnect button can be clicked while still disconnected.
           */
           if (isConnectingFromConnectCall && connectionStatus === "connected") {
-            document.getElementById("connectDisconnect").innerText =
-              "Disconnect";
-            document.getElementById("connectDisconnect").title =
-              "Disconnect from the stream service. New observations will not be streamed until reconnecting.";
-            document.getElementById("connectDisconnect")
-              .classList.remove("esri-button--disabled");
+            setConnectDisconnectButtonToDisconnect();
+            enableButton("connectDisconnect");
 
-            document.getElementById("clearPreviousObservations")
-              .classList.remove("esri-button--disabled")
+            enableButton("clearPreviousObservations");
 
-            document.getElementById("pauseResume").innerText =
-              "Pause";
-            document.getElementById("pauseResume").title =
-              "Pause the connection to stop new observations from being applied until resuming. Data will be received but will not update the layer view until resumed.";
-            document.getElementById("pauseResume")
-              .classList.remove("esri-button--disabled");
+            setPauseResumeButtonToPause();
+            enableButton("pauseResume");
 
             isConnectingFromConnectCall = false;
           }
@@ -419,9 +417,7 @@
           if (streamLayer) {
             streamLayer.sendMessageToSocket({ filter: { geometry: null } });
           }
-          document
-            .getElementById("clearSpatialFilter")
-            .classList.add("esri-button--disabled");
+          disableButton("clearSpatialFilter");
         }
 
         function drawSpatialFilter(geometry) {

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -5,10 +5,10 @@
     <title>Stream Service Viewer</title>
     <link
       rel="stylesheet"
-      href="https://js.arcgis.com/4.27/esri/themes/light/main.css"
+      href="https://js.arcgis.com/4.29/esri/themes/light/main.css"
     />
     <link rel="stylesheet" href="./streamServiceViewerStyles.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
+    <script src="https://js.arcgis.com/4.29/"></script>
     <script>
       require([
         "esri/Map",

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -197,17 +197,32 @@
           if (streamLayerView) {
             if (streamLayerView.connectionStatus === "disconnected") {
               streamLayerView.connect();
-              document.getElementById("connectDisconnect").innerText = "Disconnect";
+              document.getElementById("connectDisconnect").innerText =
+                "Disconnect";
 
               document.getElementById("clearPreviousObservations")
                 .classList.remove("esri-button--disabled")
+
+              document.getElementById("subscribeUnsubscribe").innerText =
+                "Unsubscribe";
+              document.getElementById("subscribeUnsubscribe")
+                .classList.remove("esri-button--disabled");
             } else {
               streamLayerView.disconnect();
-              document.getElementById("connectDisconnect").innerText = "Connect";
+              document.getElementById("connectDisconnect").innerText =
+                "Connect";
 
               // Previous observations cannot be cleared when disconnected.
               document.getElementById("clearPreviousObservations")
                 .classList.add("esri-button--disabled")
+
+              // Pausing / resuming a disconnected stream layer has no effect,
+              // so we'll disable the button and set it up so the user can
+              // subscribe again
+              document.getElementById("subscribeUnsubscribe").innerText =
+                "Subscribe";
+              document.getElementById("subscribeUnsubscribe")
+                .classList.add("esri-button--disabled");
             }
           }
         }

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -21,7 +21,8 @@
         "esri/layers/GraphicsLayer",
         "esri/widgets/Expand",
         "esri/widgets/LayerList",
-        "esri/widgets/Legend"
+        "esri/widgets/Legend",
+        "esri/core/reactiveUtils"
       ], function (
         Map,
         MapView,
@@ -33,7 +34,8 @@
         GraphicsLayer,
         Expand,
         LayerList,
-        Legend
+        Legend,
+        reactiveUtils
       ) {
         let map,
           mapView,
@@ -42,7 +44,8 @@
           streamLayer,
           streamLayerView,
           spatialFilter,
-          expressionFilter;
+          expressionFilter,
+          isConnectingFromConnectCall;
 
         function init() {
           map = new Map({
@@ -197,16 +200,19 @@
           if (streamLayerView) {
             if (streamLayerView.connectionStatus === "disconnected") {
               streamLayerView.connect();
+
+              /*
+              * The button is disabled and relevant text is displayed
+              * to prevent a bug where the user can click disconnect while
+              * disconnected. Handling for when the layer is connected is
+              * in the layer's connection status change handler.
+              */
               document.getElementById("connectDisconnect").innerText =
-                "Disconnect";
+                    "Connecting";
+                  document.getElementById("connectDisconnect")
+                    .classList.add("esri-button--disabled");
 
-              document.getElementById("clearPreviousObservations")
-                .classList.remove("esri-button--disabled")
-
-              document.getElementById("pauseResume").innerText =
-                "Pause";
-              document.getElementById("pauseResume")
-                .classList.remove("esri-button--disabled");
+              isConnectingFromConnectCall = true;
             } else {
               streamLayerView.disconnect();
               document.getElementById("connectDisconnect").innerText =
@@ -258,6 +264,11 @@
               removeStreamLayer();
               createToaster("Error connecting to the Stream Service", "error");
             });
+
+            reactiveUtils.watch(
+              () => layerView.connectionStatus,
+              () => onConnectionStatusChange(layerView.connectionStatus)
+            )
 
             streamLayer.popupTemplate = streamLayer.createPopupTemplate();
           });
@@ -332,6 +343,30 @@
                 "success"
               );
             }
+          }
+        }
+
+        function onConnectionStatusChange(connectionStatus) {
+          /*
+          * This will fire if the user has clicked the "connect" button after a
+          * disconnect. This will prevent a bug from occurring where the
+          * disconnect button can be clicked while still disconnected.
+          */
+          if (isConnectingFromConnectCall && connectionStatus === "connected") {
+            document.getElementById("connectDisconnect").innerText =
+              "Disconnect";
+            document.getElementById("connectDisconnect")
+              .classList.remove("esri-button--disabled");
+
+            document.getElementById("clearPreviousObservations")
+              .classList.remove("esri-button--disabled")
+
+            document.getElementById("pauseResume").innerText =
+              "Pause";
+            document.getElementById("pauseResume")
+              .classList.remove("esri-button--disabled");
+
+            isConnectingFromConnectCall = false;
           }
         }
 


### PR DESCRIPTION
### Description
This PR enhances the stream service viewer to use JSAPI version 4.29, and use the new `connect` and `disconnect` methods on the `streamLayerView`. It adds a new "connect/disconnect" button which uses the new API, and adds handling around the different connection states. A new checkbox was also added that allows for toggling between applying filters with websockets or by changing the layer's properties. It also makes some cleanup changes to reduce repeated code.

### Test
To test this PR, you can open the currentViewer file in your web browser, and connect to the default stream service.