### PR TITLE
Add tooltip to websocket message checkbox

### DIFF
--- a/currentViewer.html
+++ b/currentViewer.html
@@ -581,7 +581,12 @@
               class="esri-input"
               type="checkbox"
             />
-            <label for="useSendMessageToSocket">Use sendMessageToSocket API</label>
+            <label
+              for="useSendMessageToSocket"
+              title="When unchecked, the app logic will clear previous observations when setting new filters."
+            >
+              Use sendMessageToSocket API
+            </label>
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Description
This PR adds a tooltip to the websocket message checkbox that helps to explain what happens when the checkbox is checked/unchecked.