### PR TITLE
Update JS API Version to Latest 4.x

### DIFF
--- a/currentViewer.html
+++ b/currentViewer.html
@@ -8,7 +8,7 @@
       href="https://js.arcgis.com/4.29/esri/themes/light/main.css"
     />
     <link rel="stylesheet" href="./streamServiceViewerStyles.css" />
-    <script src="https://js.arcgis.com/4.29/"></script>
+    <script src="https://js.arcgis.com/4.31/"></script>
     <script>
       require([
         "esri/Map",
@@ -270,6 +270,8 @@
           //url to stream service
           const svcUrl = document.getElementById("streamServiceUrl").value;
 
+          try {
+
           //construct Stream Layer
           streamLayer = new StreamLayer({
             url: svcUrl,
@@ -282,7 +284,9 @@
 
           //Add layer to map
           map.add(streamLayer);
-
+        } catch (error) {
+          console.erorr(e)
+        }
           //When layer loads, register listeners for layer events and add layer to map
           mapView.whenLayerView(streamLayer).then(function (layerView) {
             streamLayerView = layerView;

--- a/currentViewer.html
+++ b/currentViewer.html
@@ -270,8 +270,6 @@
           //url to stream service
           const svcUrl = document.getElementById("streamServiceUrl").value;
 
-          try {
-
           //construct Stream Layer
           streamLayer = new StreamLayer({
             url: svcUrl,
@@ -284,9 +282,7 @@
 
           //Add layer to map
           map.add(streamLayer);
-        } catch (error) {
-          console.erorr(e)
-        }
+
           //When layer loads, register listeners for layer events and add layer to map
           mapView.whenLayerView(streamLayer).then(function (layerView) {
             streamLayerView = layerView;


### PR DESCRIPTION
This PR updates the version of the JS API used within the currentViewer page to the latest 4.x version. After testing, all functionality seems to be the same.